### PR TITLE
Allow for multiple paths and wildcards in the readers

### DIFF
--- a/src/biome/data/__init__.py
+++ b/src/biome/data/__init__.py
@@ -1,3 +1,11 @@
+import pkg_resources
+
+try:
+    __version__ = pkg_resources.get_distribution(__name__.replace(".", "-")).version
+except pkg_resources.DistributionNotFound:
+    # package is not installed
+    pass
+
 ENV_DASK_CLUSTER = "DASK_CLUSTER"
 ENV_DASK_CACHE_SIZE = "DASK_CACHE_SIZE"
 DEFAULT_DASK_CACHE_SIZE = 2e9

--- a/src/biome/data/sources/readers.py
+++ b/src/biome/data/sources/readers.py
@@ -156,7 +156,6 @@ def from_elasticsearch(
     npartitions: int = 2,
     client_cls: Optional = None,
     client_kwargs=None,
-    source_only: Optional[bool] = None,
     **kwargs,
 ) -> dd.DataFrame:
     """Reads documents from Elasticsearch.
@@ -195,9 +194,6 @@ def from_elasticsearch(
 
     """
 
-    if source_only is not None:
-        warnings.warn("source-only field will be removed", DeprecationWarning)
-
     if npartitions < 2:
         _logger.warning(
             "A minium of 2 partitions is needed for elasticsearch scan slices....Setting partitions number to 2"
@@ -218,10 +214,10 @@ def from_elasticsearch(
         ]
     ]
 
-    return dask.dataframe.from_delayed(index_scan)
+    return dd.from_delayed(index_scan)
 
 
-def _elasticsearch_scan(client_cls, client_kwargs, **params) -> pandas.DataFrame:
+def _elasticsearch_scan(client_cls, client_kwargs, **params) -> pd.DataFrame:
     def map_to_source(x: Dict) -> Dict:
         flat = flatdict.FlatDict(
             {**x["_source"], **dict(id=x["_id"], resource=x["_index"])}, delimiter="."
@@ -232,7 +228,7 @@ def _elasticsearch_scan(client_cls, client_kwargs, **params) -> pandas.DataFrame
     # the ES client as it cannot be serialized.
     # TODO check empty DataFrame
     client = client_cls(**(client_kwargs or {}))
-    df = pandas.DataFrame(
+    df = pd.DataFrame(
         (map_to_source(document) for document in scan(client, **params))
     )
 

--- a/src/biome/data/sources/readers.py
+++ b/src/biome/data/sources/readers.py
@@ -27,7 +27,7 @@ def from_csv(path: Union[str, List[str]], **params) -> dd.DataFrame:
     path
         Path to files
     params
-        Extra arguments passed on to `pandas.read_csv`
+        Extra arguments passed on to `dask.dataframe.read_csv`
 
     Returns
     -------
@@ -35,14 +35,7 @@ def from_csv(path: Union[str, List[str]], **params) -> dd.DataFrame:
         A `dask.DataFrame`
 
     """
-    path_list = _get_file_paths(path)
-
-    dds = []
-    for path_name in path_list:
-        ddf = dd.read_csv(path_name, include_path_column=True, **params)
-        dds.append(ddf)
-
-    return dd.concat(dds)
+    return dd.read_csv(path, include_path_column=True, **params)
 
 
 def from_json(


### PR DESCRIPTION
This is a PR that i had pending for a while.

In the past we supported a list of paths in the data source yaml and also wildcards.
This got lost and i reintroduce it here.

I also implemented a better excel reader, that uses less memory, since it does not load the DataFrames into memory.

All tests pass locally.