### PR TITLE
fix: dask.cache requires cachey module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ if __name__ == "__main__":
         package_dir={"": "src"},
         install_requires=[
             "dask[complete]~=2.0",
+            "cachey~=0.1",  # required by dask.cache
             "pyarrow~=0.14",
             "ujson~=1.35",
             "pandas~=0.25.0",


### PR DESCRIPTION
Using dask cache makes the process fails since cachey package is required. So, we define cachey as required dependency.