### PR TITLE
fix: allow define forward configuration without a label

### DIFF
--- a/src/biome/data/sources/datasource.py
+++ b/src/biome/data/sources/datasource.py
@@ -145,11 +145,13 @@ class DataSource:
         # This is strictly a shallow copy of the underlying computational graph
         forward_dataframe = self._df.copy()
 
-        forward_dataframe["label"] = (
-            forward_dataframe[self.forward.label]
-            .astype(str)
-            .apply(self.forward.sanitize_label, meta=("label", "object"))
-        )
+        if self.forward.label:
+            forward_dataframe["label"] = (
+                forward_dataframe[self.forward.label]
+                .astype(str)
+                .apply(self.forward.sanitize_label, meta=("label", "object"))
+            )
+
         self._add_forward_token_columns(forward_dataframe)
 
         return forward_dataframe

--- a/tests/data/sources/test_datasource.py
+++ b/tests/data/sources/test_datasource.py
@@ -58,3 +58,14 @@ class DataSourceTest(DaskSupportTest):
             self.assertIn(
                 v, ds.forward.metadata.values(), f"Value {v} should be in metadata"
             )
+
+    def test_read_forward_without_label(self):
+
+        ds = DataSource(
+            format="json",
+            forward=ClassificationForwardConfiguration(tokens="summary"),
+            path=os.path.join(FILES_PATH, "dataset_source.jsonl"),
+        )
+
+        ddf = ds.to_forward_dataframe()
+        self.assertNotIn("label", ddf.columns)


### PR DESCRIPTION
This PR fixs problems with `DataSources` defining a forward configuration just with features and no  label