### PR TITLE
fix: passing path_keys recursively

### DIFF
--- a/src/biome/data/sources/utils.py
+++ b/src/biome/data/sources/utils.py
@@ -70,7 +70,7 @@ def make_paths_relative(
     """
     for k, v in cfg_dict.items():
         if isinstance(v, dict):
-            make_paths_relative(yaml_dirname, v)
+            make_paths_relative(yaml_dirname, v, path_keys)
 
         if path_keys and k not in path_keys:
             continue


### PR DESCRIPTION
This PR fixes a error expanding paths that made me cry using de elasticsearch query, since it was expanding the query values (oh yeah!)