### PR TITLE
Using dask elk for datasource

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,6 @@ max-line-length = 120
 disable = C0330,C0111
 skip = docs/*.py
 output-format = colorized
-score = n
+score = y
 reports = n
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ exclude =
 
 [pylint]
 max-line-length = 120
-disable = C0330
+disable = C0330,C0111
 skip = docs/*.py
 output-format = colorized
 score = n

--- a/setup.py
+++ b/setup.py
@@ -21,14 +21,12 @@ if __name__ == "__main__":
             "pyarrow~=0.14",
             "ujson~=1.35",
             "pandas~=0.25.0",
-            "elasticsearch~=6.0",
+            "dask-elk~=0.2.0",
             "bokeh~=1.3",
             "xlrd~=1.2",
             "flatdict~=3.4",
         ],
-        extras_require={
-            "testing": ["pytest", "pytest-cov", "pytest-pylint", "black"]
-        },
+        extras_require={"testing": ["pytest", "pytest-cov", "pytest-pylint", "black"]},
         python_requires=">=3.6.1",
         zip_safe=False,
     )

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ if __name__ == "__main__":
             "pyarrow~=0.14",
             "ujson~=1.35",
             "pandas~=0.25.0",
+            "elasticsearch<7.0",  # latest version doesn't work with dask-elk module
             "dask-elk~=0.2.0",
             "bokeh~=1.3",
             "xlrd~=1.2",

--- a/src/biome/data/__init__.py
+++ b/src/biome/data/__init__.py
@@ -9,5 +9,8 @@ except pkg_resources.DistributionNotFound:
     pass
 
 # TODO : remove from here and/or remove if not needed
+ENV_DASK_CLUSTER = "DASK_CLUSTER"
 ENV_DASK_CACHE_SIZE = "DASK_CACHE_SIZE"
 DEFAULT_DASK_CACHE_SIZE = 2e9
+
+ENV_ES_HOSTS = "ES_HOSTS"

--- a/src/biome/data/__init__.py
+++ b/src/biome/data/__init__.py
@@ -1,13 +1,13 @@
 import pkg_resources
 
+from .sources import DataSource
+
 try:
     __version__ = pkg_resources.get_distribution(__name__.replace(".", "-")).version
 except pkg_resources.DistributionNotFound:
     # package is not installed
     pass
 
-ENV_DASK_CLUSTER = "DASK_CLUSTER"
+# TODO : remove from here and/or remove if not needed
 ENV_DASK_CACHE_SIZE = "DASK_CACHE_SIZE"
 DEFAULT_DASK_CACHE_SIZE = 2e9
-
-ENV_ES_HOSTS = "ES_HOSTS"

--- a/src/biome/data/sources/__init__.py
+++ b/src/biome/data/sources/__init__.py
@@ -1,2 +1,1 @@
 from .datasource import DataSource
-from .utils import ID, RESOURCE

--- a/src/biome/data/sources/datasource.py
+++ b/src/biome/data/sources/datasource.py
@@ -1,22 +1,23 @@
 import logging
 import os.path
-from typing import Dict, Callable, Any, Union, List, Optional, Tuple
 import warnings
+from typing import Dict, Callable, Any, Union, List, Optional, Tuple
 
 import yaml
 from dask.bag import Bag
 from dask.dataframe import DataFrame
 
-from biome.data.sources.readers import (
+from .readers import (
+    ID,
+    RESOURCE,
+    PATH_COLUM_NAME,
     from_csv,
     from_json,
     from_excel,
-    from_elasticsearch,
     from_parquet,
+    ElasticsearchDataFrameReader,
 )
-from biome.data.sources.utils import make_paths_relative
-
-from .utils import row2dict
+from .utils import make_paths_relative
 
 
 class DataSource:
@@ -52,7 +53,10 @@ class DataSource:
         "json-l": (from_json, dict()),
         "parquet": (from_parquet, dict()),
         # No file system based readers
-        "elasticsearch": (from_elasticsearch, dict()),
+        ElasticsearchDataFrameReader.SOURCE_TYPE: (
+            ElasticsearchDataFrameReader.read,
+            dict(),
+        ),
     }
     # maps the supported formats to the corresponding "source readers"
 
@@ -80,14 +84,13 @@ class DataSource:
 
         source_reader, defaults = self._find_reader(format)
         reader_arguments = {**defaults, **kwargs, **attributes}
-        # TODO this should be managed by an FileSystemDataSourceReader class or something like that,
-        #  but we just check non file-based formats to keep backward compatibility
-        if source and format not in ["elasticsearch"]:
-            df = source_reader(path=source, **reader_arguments).dropna(how="all")
-        else:
-            df = source_reader(**reader_arguments).dropna(how="all")
 
-        df = df.rename(
+        df = (
+            source_reader(source, **reader_arguments)
+            if source
+            else source_reader(**reader_arguments)
+        )
+        df = df.dropna(how="all").rename(
             columns={column: column.strip() for column in df.columns.astype(str).values}
         )
         # TODO allow disable index reindex
@@ -129,7 +132,7 @@ class DataSource:
         """
         dict_keys = [str(column).strip() for column in self._df.columns]
 
-        return self._df.to_bag(index=True).map(row2dict, columns=dict_keys)
+        return self._df.to_bag(index=True).map(self._row2dict, columns=dict_keys)
 
     def to_mapped_bag(self) -> Bag:
         """Turns the mapped DataFrame of the data source into a `dask.Bag` of dictionaries, one dict for each row.
@@ -142,7 +145,7 @@ class DataSource:
         """
         mapped_df = self.to_mapped_dataframe()
         dict_keys = [str(column).strip() for column in mapped_df.columns]
-        return mapped_df.to_bag(index=True).map(row2dict, columns=dict_keys)
+        return mapped_df.to_bag(index=True).map(self._row2dict, columns=dict_keys)
 
     def to_dataframe(self) -> DataFrame:
         """Returns the underlying DataFrame of the data source"""
@@ -178,13 +181,34 @@ class DataSource:
 
         return mapped_dataframe
 
-    def _to_dict_or_str(self, value: "pandas.Series") -> Union[Dict, str]:
+    @staticmethod
+    def _to_dict_or_str(value: "pandas.Series") -> Union[Dict, str]:
         """Transform a `pandas.Series` of strings to a dict or a str, depending on its length.
         Also applies a strip() to the strings."""
         if len(value) > 1:
             return value.to_dict()
         else:
             return str(value.iloc[0])
+
+    @staticmethod
+    def _row2dict(
+        row: Tuple, columns: List[str], default_path: Optional[str] = None
+    ) -> Dict[str, Any]:
+        """ Convert a pandas row into a dict object """
+        id = row[0]
+        data = row[1:]
+
+        # For duplicated column names, pandas append a index prefix with dots '.' We prevent
+        # index failures by replacing for '_'
+        sanitized_columns = [column.replace(".", "_") for column in columns]
+        data = dict([(ID, id)] + list(zip(sanitized_columns, data)))
+
+        # DataFrame.read_csv allows include path column called `path`
+        data[RESOURCE] = data.get(
+            RESOURCE, data.get(PATH_COLUM_NAME, str(default_path))
+        )
+
+        return data
 
     @classmethod
     def from_yaml(cls: "DataSource", file_path: str) -> "DataSource":

--- a/src/biome/data/sources/datasource.py
+++ b/src/biome/data/sources/datasource.py
@@ -10,7 +10,7 @@ from dask.dataframe import DataFrame
 from .readers import (
     ID,
     RESOURCE,
-    PATH_COLUM_NAME,
+    PATH_COLUMN_NAME,
     from_csv,
     from_json,
     from_excel,
@@ -205,7 +205,7 @@ class DataSource:
 
         # DataFrame.read_csv allows include path column called `path`
         data[RESOURCE] = data.get(
-            RESOURCE, data.get(PATH_COLUM_NAME, str(default_path))
+            RESOURCE, data.get(PATH_COLUMN_NAME, str(default_path))
         )
 
         return data

--- a/src/biome/data/sources/readers.py
+++ b/src/biome/data/sources/readers.py
@@ -14,7 +14,7 @@ from biome.data.sources.utils import flatten_dataframe, flatten_dask_dataframe
 
 ID = "id"
 RESOURCE = "resource"
-PATH_COLUM_NAME = "path"
+PATH_COLUMN_NAME = "path"
 
 
 _logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
@@ -63,7 +63,7 @@ def from_csv(path: Union[str, List[str]], **params) -> dd.DataFrame:
         A `dask.DataFrame`
 
     """
-    return dd.read_csv(path, include_path_column=True, **params)
+    return dd.read_csv(path, include_path_column=PATH_COLUMN_NAME, **params)
 
 
 def from_json(
@@ -96,7 +96,7 @@ def from_json(
     dds = []
     for path_name in path_list:
         ddf = dd.read_json(path_name, flatten=flatten, engine=json_engine, **params)
-        ddf[PATH_COLUM_NAME] = path_name
+        ddf[PATH_COLUMN_NAME] = path_name
         dds.append(ddf)
 
     return dd.concat(dds)
@@ -123,7 +123,7 @@ def from_parquet(path: Union[str, List[str]], **params) -> dd.DataFrame:
     dds = []
     for path_name in path_list:
         ddf = dd.read_parquet(path_name, engine="pyarrow", **params)
-        ddf[PATH_COLUM_NAME] = path_name
+        ddf[PATH_COLUMN_NAME] = path_name
         dds.append(ddf)
 
     return dd.concat(dds)
@@ -151,7 +151,7 @@ def from_excel(path: Union[str, List[str]], **params) -> dd.DataFrame:
     for path_name in path_list:
         parts = delayed(pd.read_excel)(path_name, **params)
         df = dd.from_delayed(parts).fillna("")
-        df[PATH_COLUM_NAME] = path_name
+        df[PATH_COLUMN_NAME] = path_name
         dds.append(df)
 
     return dd.concat(dds)

--- a/src/biome/data/sources/readers.py
+++ b/src/biome/data/sources/readers.py
@@ -1,20 +1,49 @@
 import glob
 import logging
 from glob import glob
-from typing import Dict, Optional, Union, List
+from typing import Optional, Union, List
+from urllib.parse import urlparse
 
+import dask
 import dask.dataframe as dd
-import flatdict
 import pandas as pd
 from dask import delayed
-from elasticsearch import Elasticsearch
-from elasticsearch.helpers import scan
+from dask_elk.client import DaskElasticClient
 
-from biome.data.sources.utils import flatten_dataframe
+from biome.data.sources.utils import flatten_dataframe, flatten_dask_dataframe
 
-_logger = logging.getLogger(__name__)
+ID = "id"
+RESOURCE = "resource"
+PATH_COLUM_NAME = "path"
+
+
+_logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 # TODO: The idea is to make the readers a class and define a metaclass that they have to follow.
-#       For now, all reader methods have to return a dask.DataFrame
+#       For now, all reader methods have to return a dask.DataFrame. See ElasticsearchDataFrameReader
+
+
+class DataFrameReader:
+    """A base class for read :class:dask.dataframe.DataFrame
+    """
+
+    @classmethod
+    def read(cls, source: Union[str, List[str]], **kwargs) -> dask.dataframe.DataFrame:
+        """
+        Base class method for read the DataSources as a :class:dask.dataframe.DataFrame
+
+        Parameters
+        ----------
+        source: The source information.
+        kwargs: extra arguments passed to read method. Each reader should declare needed arguments
+
+        Returns
+        -------
+
+        A :class:dask.dataframe.DataFrame read from source
+
+        """
+
+        raise NotImplementedError
 
 
 def from_csv(path: Union[str, List[str]], **params) -> dd.DataFrame:
@@ -67,7 +96,7 @@ def from_json(
     dds = []
     for path_name in path_list:
         ddf = dd.read_json(path_name, flatten=flatten, engine=json_engine, **params)
-        ddf["path"] = path_name
+        ddf[PATH_COLUM_NAME] = path_name
         dds.append(ddf)
 
     return dd.concat(dds)
@@ -93,8 +122,8 @@ def from_parquet(path: Union[str, List[str]], **params) -> dd.DataFrame:
 
     dds = []
     for path_name in path_list:
-        ddf = dd.read_parquet(path_name, **params, engine="pyarrow")
-        ddf["path"] = path_name
+        ddf = dd.read_parquet(path_name, engine="pyarrow", **params)
+        ddf[PATH_COLUM_NAME] = path_name
         dds.append(ddf)
 
     return dd.concat(dds)
@@ -122,7 +151,7 @@ def from_excel(path: Union[str, List[str]], **params) -> dd.DataFrame:
     for path_name in path_list:
         parts = delayed(pd.read_excel)(path_name, **params)
         df = dd.from_delayed(parts).fillna("")
-        df["path"] = path_name
+        df[PATH_COLUM_NAME] = path_name
         dds.append(df)
 
     return dd.concat(dds)
@@ -150,83 +179,65 @@ def _get_file_paths(paths: Union[str, List[str]]) -> List[str]:
     return [path for sublist in path_lists for path in sublist]
 
 
-def from_elasticsearch(
-    query: Optional[Dict] = None,
-    npartitions: int = 2,
-    client_cls: Optional = None,
-    client_kwargs=None,
-    **kwargs,
-) -> dd.DataFrame:
-    """Reads documents from Elasticsearch.
-
-    By default, documents are sorted by ``_doc``. For more information see the
-    scrolling section in Elasticsearch documentation.
-
-    Parameters
-    ----------
-    query : dict, optional
-        Search query.
-    npartitions : int, optional
-        Number of partitions, default is 2.
-    client_cls : elasticsearch.Elasticsearch, optional
-        Elasticsearch client class.
-    client_kwargs : dict, optional
-        Elasticsearch client parameters.
-    **params
-        Additional keyword arguments are passed to the the
-        ``elasticsearch.helpers.scan`` function.
-
-    Returns
-    -------
-    out : List[Delayed]
-        A list of ``dask.Delayed`` objects.
-
-    Examples
-    --------
-
-    Get all documents in elasticsearch.
-    >>> docs = from_elasticsearch()
-
-    Get documents matching a given query.
-    >>> query = {"query": {"match_all": {}}}
-    >>> docs = from_elasticsearch(query, index="myindex", doc_type="stuff")
-
+class ElasticsearchDataFrameReader(DataFrameReader):
+    """
+        Read a :class:dask.dataframe.DataFrame from a elasticsearch index
     """
 
-    if npartitions < 2:
-        _logger.warning(
-            "A minium of 2 partitions is needed for elasticsearch scan slices....Setting partitions number to 2"
-        )
-        npartitions = 2
+    SOURCE_TYPE = "elasticsearch"
+    __ELASTIC_ID_FIELD = "_id"
 
-    query = query or {}
-    # Sorting by _doc is preferred for scrolling.
-    query.setdefault("sort", ["_doc"])
-    if client_cls is None:
-        client_cls = Elasticsearch
-    # We load documents in parallel using the scrolling + slicing feature.
-    index_scan = [
-        delayed(_elasticsearch_scan)(client_cls, client_kwargs, **scan_kwargs)
-        for scan_kwargs in [
-            dict(kwargs, query=dict(query, slice=slice))
-            for slice in [{"id": idx, "max": npartitions} for idx in range(npartitions)]
-        ]
-    ]
+    @classmethod
+    def read(
+        cls,
+        source: Union[str, List[str]],
+        index: str,
+        doc_type: str = "_doc",
+        query: Optional[dict] = None,
+        es_host: str = "http://localhost:9200",
+        flatten_content: bool = False,
+        **kwargs,
+    ) -> dask.dataframe.DataFrame:
+        """
+        Creates a :class:dask.dataframe.DataFrame from a elasticsearch indexes
 
-    return dd.from_delayed(index_scan)
+        Parameters
+        ----------
+        source
+            The source param must match with :class:ElasticsearchDataFrameReader.SOURCE_TYPE
+        es_host
+            The elasticsearch host url (default to "http://localhost:9200")
+        index
+            The elasticsearch index
+        doc_type
+            The elasticsearch document type (default to "_doc")
+        query
+            The index query applied for extract the data
+        flatten_content
+            If True, applies a flatten to all nested data. It may take time to apply this flatten, so
+            is deactivate by default.
+        kwargs
+            Extra arguments passed to base search method
 
+        Returns
+        -------
+        A :class:dask.dataframe.DataFrame with index query results
 
-def _elasticsearch_scan(client_cls, client_kwargs, **params) -> pd.DataFrame:
-    def map_to_source(x: Dict) -> Dict:
-        flat = flatdict.FlatDict(
-            {**x["_source"], **dict(id=x["_id"], resource=x["_index"])}, delimiter="."
-        )
-        return dict(flat)
+        """
+        if source != cls.SOURCE_TYPE:
+            raise TypeError(f"{source} is not processable with {cls.__class__} reader")
 
-    # This method is executed in the worker's process and here we instantiate
-    # the ES client as it cannot be serialized.
-    # TODO check empty DataFrame
-    client = client_cls(**(client_kwargs or {}))
-    df = pd.DataFrame((map_to_source(document) for document in scan(client, **params)))
+        url = urlparse(es_host)
+        client = DaskElasticClient(host=url.hostname, port=url.port, wan_only=True)
+        df = client.read(
+            query=query, index=index, doc_type=doc_type, **kwargs
+        ).persist()
 
-    return df.set_index("id") if not df.empty else df
+        if flatten_content:
+            df = flatten_dask_dataframe(df)
+        df[RESOURCE] = f"{index}/{doc_type}"
+
+        if cls.__ELASTIC_ID_FIELD in df.columns:
+            df = df.rename(columns={cls.__ELASTIC_ID_FIELD: ID})
+
+        return df

--- a/tests/data/sources/test_datasource.py
+++ b/tests/data/sources/test_datasource.py
@@ -17,7 +17,7 @@ class DataSourceTest(DaskSupportTest):
             DataSource(source="not-found")
 
     def test_add_mock_format(self):
-        def ds_parser(**kwargs):
+        def ds_parser(*args, **kwargs):
             from dask import dataframe as ddf
             import pandas as pd
 


### PR DESCRIPTION
This PR includes to basic changes:

1. Define a new `DataFrameReader` class which tries to standardize the way a new data source reader is define.

2. Creates a `ElasticsearchDataFrameReader` replacing the old `from_elasticsearch` method, and using the `dask-elk` library for that purpose. 

The other are minimal changes affecting to functions, methods and constant definitions reorganization.