### PR TITLE
separate source df from mapped df

### DIFF
--- a/src/biome/data/sources/datasource.py
+++ b/src/biome/data/sources/datasource.py
@@ -184,7 +184,7 @@ class DataSource:
 
     @staticmethod
     def _to_dict_or_any(value: dd.Series) -> Union[Dict, Any]:
-        """Transform a `dask.dataframe.Series` of strings to a dict or a str, depending on its length."""
+        """Transform a `dask.dataframe.Series` to a dict or a single value, depending on its length."""
         if len(value) > 1:
             return value.to_dict()
         else:

--- a/src/biome/data/sources/datasource.py
+++ b/src/biome/data/sources/datasource.py
@@ -174,13 +174,13 @@ class DataSource:
                 data_features = [data_features]
 
             try:
-                mapped_dataframe[parameter_name] = self._df.loc[:, data_features].apply(
+                mapped_dataframe[parameter_name] = self._df[data_features].apply(
                     self._to_dict_or_any, axis=1, meta=(None, "object")
                 )
             except KeyError as e:
                 raise KeyError(e, f"Did not find {data_features} in the data source!")
 
-        return mapped_dataframe.loc[:, list(self.mapping.keys())]
+        return mapped_dataframe[list(self.mapping.keys())]
 
     @staticmethod
     def _to_dict_or_any(value: dd.Series) -> Union[Dict, Any]:

--- a/src/biome/data/sources/datasource.py
+++ b/src/biome/data/sources/datasource.py
@@ -5,7 +5,7 @@ from typing import Dict, Callable, Any, Union, List, Optional, Tuple
 
 import yaml
 from dask.bag import Bag
-from dask.dataframe import DataFrame
+import dask.dataframe as dd
 
 from .readers import (
     ID,
@@ -23,7 +23,7 @@ from .utils import make_paths_relative
 class DataSource:
     """This class takes care of reading the data source, usually specified in a yaml file.
 
-    It uses the *source readers* to extract a `dask.DataFrame`.
+    It uses the *source readers* to extract a dask DataFrame.
 
     Parameters
     ----------
@@ -147,48 +147,48 @@ class DataSource:
         dict_keys = [str(column).strip() for column in mapped_df.columns]
         return mapped_df.to_bag(index=True).map(self._row2dict, columns=dict_keys)
 
-    def to_dataframe(self) -> DataFrame:
+    def to_dataframe(self) -> dd.DataFrame:
         """Returns the underlying DataFrame of the data source"""
         return self._df
 
-    def to_mapped_dataframe(self) -> DataFrame:
-        """
-        Adds columns to the DataFrame that are named after the parameter names in the DatasetReader's `text_to_instance`
-        method. The content of these columns is specified in the mapping dictionary.
+    def to_mapped_dataframe(self) -> dd.DataFrame:
+        """The columns of this DataFrame are named after the mapping keys, which in turn should match
+        the parameter names in the DatasetReader's `text_to_instance` method.
+        The content of these columns is specified in the mapping dictionary.
 
         Returns
         -------
         mapped_dataframe
-            Contains additional columns corresponding to the parameter names
-            of the DatasetReader's `text_to_instance` method.
+            Contains columns corresponding to the parameter names of the DatasetReader's `text_to_instance` method.
         """
+        if not self.mapping:
+            raise ValueError("For a mapped DataFrame you need to specify a mapping!")
+
         # This is strictly a shallow copy of the underlying computational graph
         mapped_dataframe = self._df.copy()
 
         for parameter_name, data_features in self.mapping.items():
             # convert to list, otherwise the axis=1 raises an error with the returned pd.Series in the try statement
-            # if no header is present, the column names are ints
+            # if no header is present in the source data, the column names are ints
             if isinstance(data_features, (str, int)):
                 data_features = [data_features]
 
             try:
-                mapped_dataframe[parameter_name] = mapped_dataframe.loc[
-                    :, data_features
-                ].apply(self._to_dict_or_str, axis=1, meta=(parameter_name, "object"))
+                mapped_dataframe[parameter_name] = self._df.loc[:, data_features].apply(
+                    self._to_dict_or_any, axis=1, meta=(None, "object")
+                )
             except KeyError as e:
                 raise KeyError(e, f"Did not find {data_features} in the data source!")
-            # if the data source df already has a parameter_name column, it will be replaced!
 
-        return mapped_dataframe
+        return mapped_dataframe.loc[:, list(self.mapping.keys())]
 
     @staticmethod
-    def _to_dict_or_str(value: "pandas.Series") -> Union[Dict, str]:
-        """Transform a `pandas.Series` of strings to a dict or a str, depending on its length.
-        Also applies a strip() to the strings."""
+    def _to_dict_or_any(value: dd.Series) -> Union[Dict, Any]:
+        """Transform a `dask.dataframe.Series` of strings to a dict or a str, depending on its length."""
         if len(value) > 1:
             return value.to_dict()
         else:
-            return str(value.iloc[0])
+            return value.iloc[0]
 
     @staticmethod
     def _row2dict(

--- a/tests/data/sources/test_datasource.py
+++ b/tests/data/sources/test_datasource.py
@@ -55,16 +55,12 @@ class DataSourceTest(DaskSupportTest):
             self.assertIn("tokens", bag)
 
     def test_no_mapping(self):
-        for ds in [
-            DataSource(
-                format="json", path=os.path.join(FILES_PATH, "dataset_source.jsonl")
-            ),
-            DataSource(source=os.path.join(FILES_PATH, "dataset_source.jsonl")),
-        ]:
 
-            self.assertTrue(
-                ds.to_mapped_dataframe().compute().equals(ds.to_dataframe().compute())
-            )
+        ds = DataSource(
+            format="json", path=os.path.join(FILES_PATH, "dataset_source.jsonl")
+        )
+        with pytest.raises(ValueError):
+            ds.to_mapped_dataframe()
 
     def test_load_multiple_formats(self):
         files = [


### PR DESCRIPTION
This PR separates the source DataFrame and the mapped DataFrame.
The advantage is that the mapped DataFrame returned by `.to_mapped_dataframe` now should only contain columns that are in the signature of the `text_to_instance` method. Advantages:
- we get rid of the `text_to_instance_with_data_filter` method 
- can add checks if the specified mapping is correct and stop the learn call early
- it should be more data efficient, since we only pass on the columns that are really used by the training

We can always do a `dd.concat([ds.to_dataframe(), ds.to_mapped_dataframe()], axis=1)` to obtain the source+mapped dataframe.

Since this change will affect biome-text and biome-classifier as well, i will open corresponding pull requests for those as well.