### PR TITLE
add s3fs to installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ if __name__ == "__main__":
             "xlrd~=1.2",
             "flatdict~=3.4",
             "python-dateutil<2.8.1",  # botocore (imported from allennlp) has this restriction
-            "s3fs",
+            "s3fs~=0.4.0",
         ],
         extras_require={"testing": ["pytest", "pytest-cov", "pytest-pylint", "black"]},
         python_requires=">=3.6.1",

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ if __name__ == "__main__":
             "xlrd~=1.2",
             "flatdict~=3.4",
             "python-dateutil<2.8.1",  # botocore (imported from allennlp) has this restriction
+            "s3fs",
         ],
         extras_require={"testing": ["pytest", "pytest-cov", "pytest-pylint", "black"]},
         python_requires=">=3.6.1",


### PR DESCRIPTION
This PR just adds the *s3fs* package to the installation requirement.

I found myself installing this package over and over again in the dev environment to be able to read data from AWS S3 ... I think biome-data is the best place to put this requirement.